### PR TITLE
GTK4対応: ウィンドウ透過修正、Waylandポップアップメニュー修正、kinoko/nekodorifのGTK4書き直し

### DIFF
--- a/lib/ninix/balloon.rb
+++ b/lib/ninix/balloon.rb
@@ -34,7 +34,7 @@ module Balloon
   Content = Struct.new(:type, :data, :attr)
   Attribute = Struct.new(:height, :color, :bold, :italic, :strike,
                          :underline, :sup, :sub, :inline, :opaque,
-                         :use_self_alpha, :clipping, :fixed, :foreground, 
+                         :use_self_alpha, :clipping, :fixed, :foreground,
                          :is_sstp_marker)
   Head = Struct.new(:valid, :x, :y)
   Point = Struct.new(:type, :value)
@@ -147,9 +147,9 @@ module Balloon
         'Charset: UTF-8',
         "Command: #{event}",
       ].join("\r\n")
-      request = [request, args.size.times.zip(args).map do |i, a|
-        "Argument#{i}: #{a}"
-      end].join("\r\n")
+      args.each_with_index do |v, i|
+        request = [request, "Argument#{i}: #{v}"].join("\r\n")
+      end
       request = [request, "\r\n\r\n"].join
       request = [[request.bytesize].pack('L'), request.force_encoding(Encoding::BINARY)].join
       @ai_write.write(request)
@@ -172,10 +172,6 @@ module Balloon
         headers[k] = v
       end
       return {proto: protocol, code: code.to_i, status: status, headers: headers}
-    end
-
-    def notify_scope_change(side)
-      send_event('OnScopeChange', side)
     end
 
     def notify_script_begin
@@ -248,11 +244,9 @@ module Balloon
     end
 
     def raise_all
-      send_event('RaiseAll', side)
     end
 
     def raise_(side)
-      send_event('Raise', side)
     end
 
     def lower_all
@@ -425,9 +419,6 @@ module Balloon
       end
     end
 
-    def notify_scope_change(side)
-    end
-
     def notify_script_begin
     end
 
@@ -441,7 +432,7 @@ module Balloon
       @communicate = []
       0.upto(3) do |i|
         key = 'c' + i.to_s
-        @communicate[i] = balloon[key] if balloon.include?(key) 
+        @communicate[i] = balloon[key] if balloon.include?(key)
       end
 
       # create balloon windows
@@ -2077,7 +2068,7 @@ module Balloon
       @communicate = []
       0.upto(3) do |i|
         key = 'c' + i.to_s
-        @communicate[i] = balloon[key] if balloon.include?(key) 
+        @communicate[i] = balloon[key] if balloon.include?(key)
       end
       for key in balloon.keys
         value = balloon[key]
@@ -2997,7 +2988,7 @@ module Balloon
       cr.save()
       # draw sstp marker
       unless @sstp_surface.nil?
-        x, y = @sstp[0]            
+        x, y = @sstp[0]
         cr.set_source(@sstp_surface.surface(write: false), x, y)
         cr.paint()
       end
@@ -4187,9 +4178,9 @@ module Balloon
       text_g = desc.get(['font.color.g', 'fontcolor.g'], :default => 0).to_i
       text_b = desc.get(['font.color.b', 'fontcolor.b'], :default => 0).to_i
       provider = Gtk::CssProvider.new
-      context = @entry.style_context
-      context.add_provider(provider, Gtk::StyleProvider::PRIORITY_USER)
-      provider.load(data: ["entry {\n",
+      Gtk::StyleContext.add_provider_for_display(
+        Gdk::Display.default, provider, Gtk::StyleProvider::PRIORITY_USER)
+      provider.load_from_string(["entry {\n",
                             'color: #',
                             sprintf('%02x', text_r),
                             sprintf('%02x', text_g),
@@ -4233,14 +4224,17 @@ module Balloon
         #darea.set_size_request(*@window.size) # XXX
       else
         box = Gtk::Box.new(orientation=Gtk::Orientation::HORIZONTAL, spacing=10)
-        box.set_border_width(10)
+        box.set_margin_start(10)
+        box.set_margin_end(10)
+        box.set_margin_top(10)
+        box.set_margin_bottom(10)
         unless ENTRY.empty?
           label = Gtk::Label.new(label=ENTRY)
-          box.pack_start(label, :expand => false, :fill => true, :padding => 0)
+          box.append(label)
           label.show()
         end
-        box.pack_start(@entry, :expand => true, :fill => true, :padding => 0)
-        @window.add(box)
+        box.append(@entry)
+        @window.set_child(box)
         box.show()
       end
     end
@@ -4419,7 +4413,7 @@ module Balloon
     def set_symbol(symbol)
       @symbol = symbol
     end
-        
+
     def set_limittime(limittime)
       begin
         limittime = Integer(limittime)

--- a/lib/ninix/kinoko.rb
+++ b/lib/ninix/kinoko.rb
@@ -30,57 +30,68 @@ module Kinoko
 
   bindtextdomain("ninix-kagari")
 
-    def initialize(accelgroup)
+    def initialize
       @parent = nil
-      @__menu_list = {}
-      @__popup_menu = Gtk::Menu.new
-      item = Gtk::MenuItem.new(:label => _('Settings...(_O)'), :use_underline => true)
-      item.signal_connect('activate') do |a, b|
-        @parent.handle_request(:GET, :edit_preferences)
-      end
-      @__popup_menu.add(item)
-      @__menu_list['settings'] = item
-      item = Gtk::MenuItem.new(:label => _('Skin(_K)'), :use_underline => true)
-      @__popup_menu.add(item)
-      @__menu_list['skin'] = item
-      item = Gtk::MenuItem.new(:label => _('Exit(_Q)'), :use_underline => true)
-      item.signal_connect('activate') do |a, b|
-        @parent.handle_request(:GET, :close)
-      end
-      @__popup_menu.add(item)
-      @__menu_list['exit'] = item
-      @__popup_menu.show_all
+      @__popover = nil
+      @__action_group = nil
     end
 
     def set_responsible(parent)
       @parent = parent
     end
 
-    def popup()
-      skin_list = @parent.handle_request(:GET, :get_skin_list)
-      set_skin_menu(skin_list)
-      @__popup_menu.popup_at_pointer(nil)
+    def setup_actions(widget)
+      group = Gio::SimpleActionGroup.new
+
+      settings_action = Gio::SimpleAction.new('settings')
+      settings_action.signal_connect('activate') do
+        @parent.handle_request(:GET, :edit_preferences)
+      end
+      group.add_action(settings_action)
+
+      exit_action = Gio::SimpleAction.new('exit')
+      exit_action.signal_connect('activate') do
+        @parent.handle_request(:GET, :close)
+      end
+      group.add_action(exit_action)
+
+      @__action_group = group
+      widget.insert_action_group('skin', group)
     end
 
-    def set_skin_menu(list)
-      key = 'skin'
-      unless list.empty?
-        menu = Gtk::Menu.new
-        for skin in list
-          item = Gtk::MenuItem.new(:label => skin['title'])
-          item.signal_connect('activate', skin) do |a, k|
-            @parent.handle_request(:GET, :select_skin, k)
-            next true
-          end
-          menu.add(item)
-          item.show()
+    def popup(widget)
+      skin_list = @parent.handle_request(:GET, :get_skin_list)
+
+      # Register dynamic skin actions
+      skin_list.each_with_index do |skin, i|
+        name = "selectskin#{i}"
+        existing = @__action_group.lookup_action(name) rescue nil
+        @__action_group.remove_action(name) if existing
+        action = Gio::SimpleAction.new(name)
+        action.signal_connect('activate') do
+          @parent.handle_request(:GET, :select_skin, skin)
         end
-        @__menu_list[key].set_submenu(menu)
-        menu.show()
-        @__menu_list[key].show()
-      else
-        @__menu_list[key].hide()
+        @__action_group.add_action(action)
       end
+
+      menu = Gio::Menu.new
+      menu.append(_('Settings...(O)'), 'skin.settings')
+
+      unless skin_list.empty?
+        skin_submenu = Gio::Menu.new
+        skin_list.each_with_index do |skin, i|
+          skin_submenu.append(skin['title'], "skin.selectskin#{i}")
+        end
+        menu.append_submenu(_('Skin(K)'), skin_submenu)
+      end
+
+      menu.append(_('Exit(Q)'), 'skin.exit')
+
+      @__popover&.unparent
+      @__popover = Gtk::PopoverMenu.new(menu)
+      @__popover.set_parent(widget)
+      @__popover.set_has_arrow(false)
+      @__popover.popup
     end
   end
 
@@ -141,7 +152,7 @@ module Kinoko
 
     def load_skin()
       scale = @target.get_surface_scale()
-      @skin = Skin.new(@accelgroup)
+      @skin = Skin.new()
       @skin.set_responsible(self)
       @skin.load(@data, scale)
     end
@@ -168,7 +179,6 @@ module Kinoko
       @data = data
       @target = target
       @target.attach_observer(self)
-      @accelgroup = Gtk::AccelGroup.new()
       load_skin()
       return 0 if @skin.nil?
       send_event('OnKinokoObjectCreate')
@@ -218,11 +228,10 @@ module Kinoko
     HANDLERS = {
     }
 
-    def initialize(accelgroup)
+    def initialize()
       @frame_buffer = []
-      @accelgroup = accelgroup
       @parent = nil
-      @__menu = Menu.new(@accelgroup)
+      @__menu = Menu.new()
       @__menu.set_responsible(self)
     end
 
@@ -254,13 +263,10 @@ module Kinoko
       @__shown = false
       @surface_id = 0 # dummy
       @window = Pix::TransparentWindow.new()
-      ##@window.set_title(['surface.', name].join(''))
-      @window.set_skip_taskbar_hint(true)
-      @window.signal_connect('delete_event') do |w, e|
-        delete(w, e)
+      @window.signal_connect('close-request') do |w|
+        delete(w)
         next true
       end
-      @window.add_accel_group(@accelgroup)
       unless @data['animation'].nil?
         path = File.join(@data['dir'], @data['animation'])
         actors = {'' => Seriko.get_actors(NConfig.create_from_file(path))}
@@ -289,30 +295,29 @@ module Kinoko
       @path = path
       @w, @h = w, h
       @darea = @window.darea
-      @darea.set_events(Gdk::EventMask::EXPOSURE_MASK|
-                        Gdk::EventMask::BUTTON_PRESS_MASK|
-                        Gdk::EventMask::BUTTON_RELEASE_MASK|
-                        Gdk::EventMask::POINTER_MOTION_MASK|
-                        Gdk::EventMask::LEAVE_NOTIFY_MASK)
-      @darea.signal_connect('button_press_event') do |w, e|
-        next button_press(w, e)
+
+      # GTK4: use draw func instead of draw signal
+      @darea.set_draw_func do |widget, cr, width, height|
+        redraw(widget, cr)
       end
-      @darea.signal_connect('button_release_event') do |w, e|
-        button_release(w, e)
-        next true
+
+      # GTK4: use gesture controllers instead of event signals
+      gesture = Gtk::GestureClick.new
+      gesture.set_button(0) # all buttons
+      gesture.signal_connect('pressed') do |g, n_press, x, y|
+        button_press(g.current_button, n_press, x, y)
       end
-      @darea.signal_connect('motion_notify_event') do |w, e|
-        motion_notify(w, e)
-        next true
+      @darea.add_controller(gesture)
+
+      motion = Gtk::EventControllerMotion.new
+      motion.signal_connect('leave') do
+        leave_notify()
       end
-      @darea.signal_connect('leave_notify_event') do |w, e|
-        leave_notify(w, e)
-        next true
-      end
-      @darea.signal_connect('draw') do |w, cr|
-        redraw(w, cr)
-        next true
-      end
+      @darea.add_controller(motion)
+
+      # Set up action group for menu
+      @__menu.setup_actions(@darea)
+
       set_position()
       show()
       reset_z_order()
@@ -331,23 +336,17 @@ module Kinoko
     end
 
     def show()
-      @window.show_all() unless @__shown
+      @window.show() unless @__shown
       @__shown = true
     end
 
     def hide()
-      @window.hide_all() if @__shown
+      @window.hide() if @__shown
       @__shown = false
     end
 
     def reset_z_order
-      return unless @__shown
-      target_window = @parent.handle_request(:GET, :get_target_window)
-      if @data['ontop']
-        @window.window.restack(target_window.window, true)
-      else
-        target_window.window.restack(@window.window, true)
-      end
+      # GTK4: window stacking not available via public API
     end
 
     def append_actor(frame, actor)
@@ -418,7 +417,6 @@ module Kinoko
           cr.mask(overlay_surface, x, y)
         end
       end
-      #@darea.queue_draw_area(0, 0, w, h)
       @image_surface = new_surface
       @darea.queue_draw()
     end
@@ -455,7 +453,6 @@ module Kinoko
       if File.exist?(path)
         @path = path
       else
-        #@path = nil
         @path = File.join(@data['dir'], @data['base'])
       end
     end
@@ -464,7 +461,7 @@ module Kinoko
       @seriko.invoke(self, actor_id, :update => update)
     end
 
-    def delete()
+    def delete(widget = nil)
       @parent.handle_request(:GET, :close)
     end
 
@@ -473,28 +470,11 @@ module Kinoko
       @window.destroy()
     end
 
-    def button_press(widget, event)
-      @x_root = event.x_root
-      @y_root = event.y_root
-      if event.event_type == Gdk::EventType::BUTTON_PRESS
-        click = 1
-      else
-        click = 2
+    def button_press(button, n_press, x, y)
+      if button == 3 && n_press == 1
+        @__menu.popup(@darea)
       end
-      button = event.button
-      if button == 3 and click == 1
-        @__menu.popup()
-      end
-      return true
-    end
-
-    def button_release(widget, event) ## FIXME
-    end
-
-    def motion_notify(widget, event) ## FIXME
-    end
-
-    def leave_notify(widget, event) ## FIXME
+      true
     end
   end
 end

--- a/lib/ninix/menu.rb
+++ b/lib/ninix/menu.rb
@@ -460,15 +460,15 @@ module Menu
       __set_nekodorif_menu()
       __set_kinoko_menu()
 
-      # Parent the popover to the ghost's own window — it's already realized
-      # and visible, so no race condition on Wayland.
-      # Re-parent if the window changed (e.g. after a shell switch).
-      if parent_window && parent_window != @__popup_window
-        @__popup_menu.unparent if @__popup_window
-        @__popup_menu.set_parent(parent_window)
-        @__popup_window = parent_window
-        @__popup_menu.signal_connect('closed') do
-          @popup_in_progress = false
+      # Re-parent the popover to the current ghost's DrawingArea when it changes.
+      if parent_window
+        if parent_window != @__popup_window
+          @__popup_menu.unparent rescue nil
+          @__popup_menu.set_parent(parent_window)
+          @__popup_window = parent_window
+          @__popup_menu.signal_connect('closed') do
+            @popup_in_progress = false
+          end
         end
       elsif @__popup_window.nil?
         # Fallback: ghost window unavailable, use a minimal 1x1 dummy
@@ -545,6 +545,11 @@ module Menu
       else
         window.maximize
       end
+    end
+
+    def reset_popup_window
+      @__popup_menu.unparent rescue nil
+      @__popup_window = nil
     end
 
     def __set_caption(name, caption)

--- a/lib/ninix/menu.rb
+++ b/lib/ninix/menu.rb
@@ -42,6 +42,8 @@ module Menu
         'sidebar' => nil
       }
       @__menu_list = {}
+      @__popup_window = nil  # initialized lazily on first popup call
+      @popup_in_progress = false
       model = Gio::Menu.new
       @__popup_menu = Gtk::PopoverMenu.new(model)
       @__popup_menu.set_has_arrow(false)
@@ -224,8 +226,7 @@ module Menu
 
     def create_css_provider_for(item)
       provider = Gtk::CssProvider.new()
-      style_context = item.style_context
-      #style_context.add_provider(provider, Gtk::StyleProvider::PRIORITY_USER)
+      # GTK4: style_context is gone; register at display level instead
       Gtk::StyleContext.add_provider_for_display(Gdk::Display.default, provider, Gtk::StyleProvider::PRIORITY_USER)
       return provider
     end
@@ -421,16 +422,13 @@ module Menu
       end
     end
 
-    def popup(side, x, y, upper)
-      @__popup_menu.popdown
-=begin TODO delete?
-      @__popup_menu.unrealize()
-      for key in @__menu_list.keys
-        item = @__menu_list[key][:entry]
-        submenu = item.submenu
-        submenu.unrealize() unless submenu.nil?
+    def popup(side, x, y, upper, parent_window = nil)
+      # Dismiss any in-progress popup before starting a new one
+      if @popup_in_progress
+        @popup_in_progress = false
+        @__popup_menu.popdown
       end
-=end
+
       if side > 1
         string = 'char' + side.to_s
       else
@@ -446,14 +444,12 @@ module Menu
       else
         portal = nil
       end
-      # FIXME implement
       __set_portal_menu(side, portal)
-      if side > 1
-        string = 'char' + side.to_s
-      else
-        fail "assert" unless [0, 1].include?(side)
-        string = ['sakura', 'kero'][side]
-      end
+      string = if side > 1
+                 'char' + side.to_s
+               else
+                 ['sakura', 'kero'][side]
+               end
       string = [string, '.recommendsites'].join('')
       recommend = @parent.handle_request(:GET, :getstring, string)
       __set_recommend_menu(recommend)
@@ -463,19 +459,38 @@ module Menu
       __set_mayuna_menu(side)
       __set_nekodorif_menu()
       __set_kinoko_menu()
-=begin FIXME alternative
-      for key in @__menu_list.keys
-        item = @__menu_list[key][:entry]
-        visible = @__menu_list[key][:visible]
-        unless item.nil?
-          if visible
-            item.show()
-          else
-            item.hide()
-          end
+
+      # Parent the popover to the ghost's own window — it's already realized
+      # and visible, so no race condition on Wayland.
+      # Re-parent if the window changed (e.g. after a shell switch).
+      if parent_window && parent_window != @__popup_window
+        @__popup_menu.unparent if @__popup_window
+        @__popup_menu.set_parent(parent_window)
+        @__popup_window = parent_window
+        @__popup_menu.signal_connect('closed') do
+          @popup_in_progress = false
         end
+      elsif @__popup_window.nil?
+        # Fallback: ghost window unavailable, use a minimal 1x1 dummy
+        orig = ENV['NINIX_MONITOR_SIZE']
+        ENV['NINIX_MONITOR_SIZE'] = '1x1'
+        @__popup_window = Pix::BaseTransparentWindow.new
+        if orig.nil?
+          ENV.delete('NINIX_MONITOR_SIZE')
+        else
+          ENV['NINIX_MONITOR_SIZE'] = orig
+        end
+        @parent.handle_request(:NOTIFY, :associate_application, @__popup_window)
+        @__popup_window.signal_connect('realize') do
+          @__popup_window.surface.set_input_region(Cairo::Region.new) rescue nil
+        end
+        @__popup_menu.set_parent(@__popup_window)
+        @__popup_menu.signal_connect('closed') do
+          @popup_in_progress = false
+        end
+        @__popup_window.show
       end
-=end
+
       @__popup_menu.set_pointing_to(Gdk::Rectangle.new(x, y, 1, 1))
 =begin
       if upper
@@ -535,11 +550,9 @@ module Menu
     def __set_caption(name, caption)
       fail "assert" unless @__menu_list.include?(name)
       fail "assert" unless caption.is_a?(String)
-      item = @__menu_list[name][:entry]
-      unless item.nil?
-        label = item.children[0]
-        label.set_text_with_mnemonic(caption)
-      end
+      # GTK4/Gio::Menu items are immutable after insertion — dynamic relabeling
+      # requires rebuilding the menu item. Stubbed until that is implemented.
+      # item = @__menu_list[name][:entry]
     end
 
     def __set_visible(name, visible)
@@ -570,7 +583,7 @@ module Menu
                 item.set_sensitive(false)
               end
 =end
-              if entry.length > 1    
+              if entry.length > 1
                 url = entry[1]
               end
               if entry.length > 2
@@ -599,7 +612,7 @@ module Menu
               else
                 banner = nil
               end
-              if entry.length > 1    
+              if entry.length > 1
                 item.signal_connect('activate', title, url) do |a, param, title, url|
                   @parent.handle_request(
                     :GET, :notify_site_selection, title, url)
@@ -984,9 +997,9 @@ module Menu
       nekodorif_menu.remove_all
       nekodorif_list.length.times do |i|
         name = nekodorif_list[i]['name']
-        item = Gio::MenuItem(name, "app.nekodorif#{i}")
+        item = Gio::MenuItem.new(name, "app.nekodorif#{i}")
         nekodorif_menu.append_item(item)
-        action = Gio::SimpleAction("nekodorif#{i}")
+        action = Gio::SimpleAction.new("nekodorif#{i}")
         action.signal_connect('activate', nekodorif_list[i]['dir']) do |a, dir|
           @parent.handle_request(:GET, :select_nekodorif, dir)
           next true
@@ -1015,9 +1028,9 @@ module Menu
       kinoko_menu.remove_all
       kinoko_list.length.times do |i|
         name = kinoko_list[i]['title']
-        item = Gio::MenuItem(name, "app.kinoko#{i}")
+        item = Gio::MenuItem.new(name, "app.kinoko#{i}")
         kinoko_menu.append_item(item)
-        action = Gio::SimpleAction("kinoko#{i}")
+        action = Gio::SimpleAction.new("kinoko#{i}")
         action.signal_connect('activate', kinoko_list[i]) do |a, k|
           @parent.handle_request(:GET, :select_kinoko, k)
           next true
@@ -1041,12 +1054,9 @@ module Menu
     end
 
     def get_stick
-      item = @__menu_list['Stick'][:entry]
-      if not item.nil? and item.active?
-        return true
-      else
-        return false
-      end
+      # 'Stick' is registered as an action but not tracked in @__menu_list
+      # (no toggle state available via Gio::SimpleAction without extra bookkeeping)
+      return false
     end
   end
 end

--- a/lib/ninix/nekodorif.rb
+++ b/lib/ninix/nekodorif.rb
@@ -10,42 +10,6 @@
 #  PURPOSE.  See the GNU General Public License for more details.
 #
 
-# TODO:
-# - 「きのこ」へのステータス送信.
-# - 「きのこ」の情報の参照.
-# - SERIKO/1.2ベースのアニメーション
-# - (スキン側の)katochan.txt
-# - balloon.txt
-# - surface[0/1/2]a.txt(@ゴースト)
-# - 自爆イベント
-# - headrect.txt : 頭の当たり判定領域データ
-#   当たり領域のleft／top／right／bottomを半角カンマでセパレートして記述.
-#   1行目がsurface0、2行目がsurface1の領域データ.
-#   このファイルがない場合、領域は自動計算される.
-# - speak.txt
-# - katochan が無い場合の処理.(本体の方のpopup menuなども含めて)
-# - 設定ダイアログ : [会話/反応]タブ -> [SEND SSTP/1.1] or [SHIORI]
-# - 見切れ連続20[s]、もしくは画面内で静止20[s]でアニメーション記述ミスと見なし自動的に落ちる
-# - 発言中にバルーンをダブルクリックで即閉じ
-# - @ゴースト名は#nameと#forには使えない. もし書いても無視されすべて有効になる
-# - 連続落し不可指定
-#   チェックしておくと落下物を2個以上同時に落とせなくなる
-# - スキンチェンジ時も起動時のトークを行う
-# - ファイルセット設定機能
-#   インストールされたスキン／落下物のうち使用するものだけを選択できる
-# - ターゲットのアイコン化への対応
-# - アイコン化されているときは自動落下しない
-# - アイコン化されているときのDirectSSTP SEND/DROPリクエストはエラー(Invisible)
-# - 落下物の透明化ON/OFF
-# - 落下物が猫どりふ自身にも落ちてくる
-#   不在時に1/2、ランダム/全員落し時に1/10の確率で自爆
-# - 一定時間間隔で勝手に物を落とす
-# - ターゲット指定落し、ランダム落し、全員落し
-# - 出現即ヒットの場合への対応
-
-# - 複数ゴーストでの当たり判定.
-# - 透明ウィンドウ
-
 require "gettext"
 require "gtk4"
 
@@ -60,58 +24,68 @@ module Nekodorif
 
   bindtextdomain("ninix-kagari")
 
-    def initialize(accelgroup)
+    def initialize
       @parent = nil
-      @__katochan_list = nil
-      @__menu_list = {}
-      @__popup_menu = Gtk::Menu.new
-      item = Gtk::MenuItem.new(:label => _('Settings...(_O)'), :use_underline => true)
-      item.signal_connect('activate') do |a, b|
-        @parent.handle_request(:GET, :edit_preferences)
-      end
-      @__popup_menu.add(item)
-      @__menu_list['settings'] = item
-      item = Gtk::MenuItem.new(:label => _('Katochan(_K)'), :use_underline => true)
-      @__popup_menu.add(item)
-      @__menu_list['katochan'] = item
-      item = Gtk::MenuItem.new(:label => _('Exit(_Q)'), :use_underline => true)
-      item.signal_connect('activate') do |a, b|
-        @parent.handle_request(:GET, :close)
-      end
-      @__popup_menu.add(item)
-      @__menu_list['exit'] = item
-      @__popup_menu.show_all
+      @__popover = nil
+      @__action_group = nil
     end
 
     def set_responsible(parent)
       @parent = parent
     end
 
-    def popup()
-      katochan_list = @parent.handle_request(:GET, :get_katochan_list)
-      __set_katochan_menu(katochan_list)
-      @__popup_menu.popup_at_pointer(nil)
+    def setup_actions(widget)
+      group = Gio::SimpleActionGroup.new
+
+      settings_action = Gio::SimpleAction.new('settings')
+      settings_action.signal_connect('activate') do
+        @parent.handle_request(:GET, :edit_preferences)
+      end
+      group.add_action(settings_action)
+
+      exit_action = Gio::SimpleAction.new('exit')
+      exit_action.signal_connect('activate') do
+        @parent.handle_request(:GET, :close)
+      end
+      group.add_action(exit_action)
+
+      @__action_group = group
+      widget.insert_action_group('neko', group)
     end
 
-    def __set_katochan_menu(list)
-      key = 'katochan'
-      unless list.empty?
-        menu = Gtk::Menu.new()
-        for katochan in list
-          item = Gtk::MenuItem.new(:label => katochan['name'])
-          item.signal_connect('activate', katochan) do |a, k|
-            @parent.handle_request(:GET, :select_katochan, k)
-            next true
-          end
-          menu.add(item)
-          item.show()
+    def popup(widget)
+      katochan_list = @parent.handle_request(:GET, :get_katochan_list)
+
+      # Register dynamic katochan actions
+      katochan_list.each_with_index do |katochan, i|
+        name = "selectkatochan#{i}"
+        existing = @__action_group.lookup_action(name) rescue nil
+        @__action_group.remove_action(name) if existing
+        action = Gio::SimpleAction.new(name)
+        action.signal_connect('activate') do
+          @parent.handle_request(:GET, :select_katochan, katochan)
         end
-        @__menu_list[key].set_submenu(menu)
-        menu.show()
-        @__menu_list[key].show()
-      else
-        @__menu_list[key].hide()
+        @__action_group.add_action(action)
       end
+
+      menu = Gio::Menu.new
+      menu.append(_('Settings...(O)'), 'neko.settings')
+
+      unless katochan_list.empty?
+        katochan_submenu = Gio::Menu.new
+        katochan_list.each_with_index do |katochan, i|
+          katochan_submenu.append(katochan['name'], "neko.selectkatochan#{i}")
+        end
+        menu.append_submenu(_('Katochan(K)'), katochan_submenu)
+      end
+
+      menu.append(_('Exit(Q)'), 'neko.exit')
+
+      @__popover&.unparent
+      @__popover = Gtk::PopoverMenu.new(menu)
+      @__popover.set_parent(widget)
+      @__popover.set_has_arrow(false)
+      @__popover.popup
     end
   end
 
@@ -146,9 +120,8 @@ module Nekodorif
       @dir = dir
       @target = target
       @target.attach_observer(self)
-      @accelgroup = Gtk::AccelGroup.new()
       scale = @target.get_surface_scale()
-      @skin = Skin.new(@dir, @accelgroup, scale)
+      @skin = Skin.new(@dir, scale)
       @skin.set_responsible(self)
       @skin.setup
       return 0 if @skin.nil?
@@ -183,17 +156,11 @@ module Nekodorif
       return false unless @__running
       @skin.update()
       @katochan.update() unless @katochan.nil?
-      #process_script()
       return true
     end
 
     def send_event(event)
-      if not ['Emerge', # 可視領域内に出現
-              'Hit',    # ヒット
-              'Drop',   # 再落下開始
-              'Vanish', # ヒットした落下物が可視領域内から消滅
-              'Dodge'   # よけられてヒットしなかった落下物が可視領域内から消滅
-             ].include?(event)
+      if not ['Emerge', 'Hit', 'Drop', 'Vanish', 'Dodge'].include?(event)
         return
       end
       args = [@katochan.get_name(),
@@ -205,11 +172,7 @@ module Nekodorif
     end
 
     def has_katochan
-      unless @katochan.nil?
-        return true
-      else
-        return false
-      end
+      !@katochan.nil?
     end
 
     def select_katochan(args)
@@ -241,8 +204,6 @@ module Nekodorif
       @target.detach_observer(self)
       @katochan.destroy() unless @katochan.nil?
       @skin.destroy() unless @skin.nil?
-      ##if self.balloon is not None:
-      ##    self.balloon.destroy()
     end
 
     def close
@@ -254,15 +215,15 @@ module Nekodorif
     HANDLERS = {
     }
 
-    def initialize(dir, accelgroup, scale)
+    def initialize(dir, scale)
       @dir = dir
-      @accelgroup = accelgroup
       @parent = nil
       @dragged = false
-      @x_root = nil
-      @y_root = nil
+      @drag_last_x = nil
+      @drag_last_y = nil
+      @button1_pressed = false
       @__scale = scale
-      @__menu = Menu.new(@accelgroup)
+      @__menu = Menu.new()
       @__menu.set_responsible(self)
       path = File.join(@dir, 'omni.txt')
       if File.file?(path) and File.size(path).zero?
@@ -273,38 +234,53 @@ module Nekodorif
       @window = Pix::TransparentWindow.new()
       name, top_dir = Home.read_profile_txt(dir) # XXX
       @window.set_title(name)
-      @window.signal_connect('delete_event') do |w, e|
-        delete(w, e)
+      @window.signal_connect('close-request') do |w|
+        delete(w)
         next true
       end
-      @window.signal_connect('key_press_event') do |w, e|
-        next key_press(w, e)
-      end
-      @window.add_accel_group(@accelgroup)
       @darea = @window.darea
-      @darea.set_events(Gdk::EventMask::EXPOSURE_MASK|
-                        Gdk::EventMask::BUTTON_PRESS_MASK|
-                        Gdk::EventMask::BUTTON_RELEASE_MASK|
-                        Gdk::EventMask::POINTER_MOTION_MASK|
-                        Gdk::EventMask::POINTER_MOTION_HINT_MASK|
-                        Gdk::EventMask::LEAVE_NOTIFY_MASK)
-      @darea.signal_connect('draw') do |w, cr|
-        redraw(w, cr)
-        next true
+
+      # GTK4: draw func
+      @darea.set_draw_func do |widget, cr, width, height|
+        redraw(widget, cr)
       end
-      @darea.signal_connect('button_press_event') do |w, e|
-        next button_press(w, e)
+
+      # GTK4: gesture controllers
+      gesture = Gtk::GestureClick.new
+      gesture.set_button(0)
+      gesture.signal_connect('pressed') do |g, n_press, x, y|
+        button_press(g.current_button, n_press, x, y)
       end
-      @darea.signal_connect('button_release_event') do |w, e|
-        next button_release(w, e)
+      gesture.signal_connect('released') do |g, n_press, x, y|
+        button_release(g.current_button)
       end
-      @darea.signal_connect('motion_notify_event') do |w, e|
-        next motion_notify(w, e)
+      @darea.add_controller(gesture)
+
+      motion = Gtk::EventControllerMotion.new
+      motion.signal_connect('motion') do |c, x, y|
+        motion_notify(x, y)
       end
-      @darea.signal_connect('leave_notify_event') do |w, e|
-        leave_notify(w, e)
-        next true
+      motion.signal_connect('leave') do
+        leave_notify()
       end
+      @darea.add_controller(motion)
+
+      # GTK4: key controller on window
+      key_controller = Gtk::EventControllerKey.new
+      key_controller.signal_connect('key-pressed') do |c, keyval, keycode, state|
+        if state & (Gdk::ModifierType::CONTROL_MASK | Gdk::ModifierType::SHIFT_MASK) != 0
+          if keyval == Gdk::Keyval::KEY_F12
+            Logging::Logging.info('reset skin position')
+            set_position(:reset => 1)
+          end
+        end
+        next false
+      end
+      @window.add_controller(key_controller)
+
+      # Set up action group for menu
+      @__menu.setup_actions(@darea)
+
       @id = [0, nil]
     end
 
@@ -329,7 +305,7 @@ module Nekodorif
     def setup
       set_surface()
       set_position(:reset => 1)
-      @window.show_all()
+      @window.show()
     end
 
     def set_scale(scale)
@@ -344,41 +320,30 @@ module Nekodorif
       @reshape = false
     end
 
-    def delete(widget, event)
+    def delete(widget = nil)
       @parent.handle_request(:GET, :finalize)
-    end
-
-    def key_press(window, event)
-      if event.state & (Gdk::ModifierType::CONTROL_MASK | Gdk::ModifierType::SHIFT_MASK)
-        if event.keyval == Gdk::Keyval::KEY_F12
-          Logging::Logging.info('reset skin position')
-          set_position(:reset => 1)
-        end
-      end
-      return true
     end
 
     def destroy
       @window.destroy()
     end
 
-    def button_press(widget, event)
-      if event.button == 1
-        if event.event_type == Gdk::EventType::BUTTON_PRESS
-          @x_root = event.x_root
-          @y_root = event.y_root
-        elsif event.event_type == Gdk::EventType::DOUBLE_BUTTON_PRESS # double click
+    def button_press(button, n_press, x, y)
+      if button == 1
+        if n_press == 1
+          @button1_pressed = true
+          @drag_last_x = x
+          @drag_last_y = y
+        elsif n_press == 2
           if @parent.handle_request(:GET, :has_katochan)
             start()
             @parent.handle_request(:GET, :drop_katochan)
           end
         end
-      elsif event.button == 3
-        if event.event_type == Gdk::EventType::BUTTON_PRESS
-          @__menu.popup()
-        end
+      elsif button == 3 && n_press == 1
+        @__menu.popup(@darea)
       end
-      return true
+      true
     end
 
     def set_surface
@@ -443,35 +408,32 @@ module Nekodorif
       set_surface()
     end
 
-    def button_release(widget, event)
-      if @dragged
-        @dragged = false
-        set_position()
-      end
-      @x_root = nil
-      @y_root = nil
-      return true
-    end
-
-    def motion_notify(widget, event)
-      x, y, state = event.x, event.y, event.state
-      if state & Gdk::ModifierType::BUTTON1_MASK
-        unless @x_root.nil? or @y_root.nil?
-          @dragged = true
-          x_delta = (event.x_root - @x_root).to_i
-          y_delta = (event.y_root - @y_root).to_i
-          move(x_delta, y_delta)
-          @x_root = event.x_root
-          @y_root = event.y_root
+    def button_release(button)
+      if button == 1
+        @button1_pressed = false
+        if @dragged
+          @dragged = false
+          set_position()
         end
+        @drag_last_x = nil
+        @drag_last_y = nil
       end
-      if event.is_hint == 1
-        Gdk::Event.request_motions(event)
-      end
-      return true
+      true
     end
 
-    def leave_notify(widget, event) ## FIXME
+    def motion_notify(x, y)
+      if @button1_pressed && !@drag_last_x.nil? && !@drag_last_y.nil?
+        x_delta = (x - @drag_last_x).to_i
+        y_delta = (y - @drag_last_y).to_i
+        @dragged = true
+        move(x_delta, y_delta)
+        @drag_last_x = x
+        @drag_last_y = y
+      end
+      true
+    end
+
+    def leave_notify ## FIXME
     end
   end
 
@@ -481,25 +443,14 @@ module Nekodorif
     end
 
     def destroy ## FIXME
-        #pass
     end
   end
 
   class Katochan
     attr_reader :loaded
 
-    CATEGORY_LIST = ['pain',      # 痛い
-                     'stab',      # 刺さる
-                     'surprise',  # びっくり
-                     'hate',      # 嫌い、気持ち悪い
-                     'huge',      # 巨大
-                     'love',      # 好き、うれしい
-                     'elegant',   # 風流、優雅
-                     'pretty',    # かわいい
-                     'food',      # 食品
-                     'reference', # 見る／読むもの
-                     'other'      # 上記カテゴリに当てはまらないもの
-                     ]
+    CATEGORY_LIST = ['pain', 'stab', 'surprise', 'hate', 'huge', 'love',
+                     'elegant', 'pretty', 'food', 'reference', 'other']
 
     def initialize(target)
       @side = 0
@@ -531,7 +482,7 @@ module Nekodorif
     end
 
     def get_kinoko_flag ## FIXME
-      return 0 # 0/1 = きのこに当たっていない(ない場合を含む)／当たった
+      return 0
     end
 
     def get_target
@@ -543,7 +494,7 @@ module Nekodorif
     end
 
     def get_ghost_name
-      if @data.include?('for') # 落下物が主に対象としているゴーストの名前
+      if @data.include?('for')
         return @data['for']
       else
         return ''
@@ -554,7 +505,7 @@ module Nekodorif
       @window.destroy()
     end
 
-    def delete(widget, event)
+    def delete(widget = nil)
       destroy()
     end
 
@@ -597,7 +548,7 @@ module Nekodorif
       end
       if @data.include?(timing + 'slide.sinwave.degspeed')
         @settings['slide.sinwave.degspeed'] = @data[timing + 'slide.sinwave.degspeed']
-        else
+      else
         @settings['slide.sinwave.degspeed'] = 30
       end
       if @data.include?(timing + 'wave')
@@ -657,7 +608,6 @@ module Nekodorif
         unless category.empty?
           unless CATEGORY_LIST.include?(category[0])
             Logging::Logging.warning('WARNING: unknown major category - ' + category[0])
-            ##@data['category'] = CATEGORY_LIST[-1]
           end
         else
           @data['category'] = CATEGORY_LIST[-1]
@@ -678,56 +628,27 @@ module Nekodorif
       end
       if @parent.handle_request(:GET, :get_mode) == 1
         @parent.handle_request(:GET, :send_event, 'Emerge')
-      else
-        if @data.include?('before.script')
-          #pass ## FIXME
-        else
-          #pass ## FIXME
-        end
       end
       set_movement('before')
-      if @data.include?('before.appear.direction')
-        #pass ## FIXME
-      else
-        #pass ## FIXME
-      end
-      if @data.include?('before.appear.ofset.x')
-        offset_x = @data['before.appear.ofset.x']
-      else
-        offset_x = 0
-      end
-      if offset_x < -32768
-        offset_x = -32768
-      end
-      if offset_x > 32767
-        offset_x = 32767
-      end
-      if @data.include?('before.appear.ofset.y')
-        offset_y = @data['before.appear.ofset.y']
-      else
-        offset_y = 0
-      end
-      if offset_y < -32768
-        offset_y = -32768
-      end
-      if offset_y > 32767
-        offset_y = 32767
-      end
+      offset_x = @data.include?('before.appear.ofset.x') ? @data['before.appear.ofset.x'] : 0
+      offset_x = [[-32768, offset_x].max, 32767].min
+      offset_y = @data.include?('before.appear.ofset.y') ? @data['before.appear.ofset.y'] : 0
+      offset_y = [[-32768, offset_y].max, 32767].min
       @offset_x = offset_x
       @offset_y = offset_y
       @window = Pix::TransparentWindow.new()
       @window.set_title(@data['name'])
-      @window.set_skip_taskbar_hint(true) # XXX
-      @window.signal_connect('delete_event') do |w, e|
-        delete(w, e)
+      @window.signal_connect('close-request') do |w|
+        delete(w)
         next true
       end
       @darea = @window.darea
-      @darea.set_events(Gdk::EventMask::EXPOSURE_MASK)
-      @darea.signal_connect('draw') do |w, cr|
-        redraw(w, cr)
-        next true
+
+      # GTK4: draw func
+      @darea.set_draw_func do |widget, cr, width, height|
+        redraw(widget, cr)
       end
+
       @window.show()
       @id = 0
       set_surface()
@@ -747,7 +668,6 @@ module Nekodorif
     end
 
     def update_surface ## FIXME
-      #pass
     end
 
     def update_position ## FIXME
@@ -759,19 +679,12 @@ module Nekodorif
           (@time / 20.0)**2)
         elsif @settings['fall.type'] == 'evenspeed'
           @y += @settings['fall.speed']
-        else
-          #pass
-        end
-        if @settings['slide.type'] == 'sinwave'
-          #pass ## FIXME
-        else
-          #pass
         end
       end
       @window.move(@x, @y)
     end
 
-    def check_collision ## FIXME: check self position
+    def check_collision ## FIXME
       for side in [0, 1]
         target_x, target_y = @target.get_surface_position(side)
         target_w, target_h = @target.get_surface_size(side)
@@ -809,17 +722,11 @@ module Nekodorif
             @id = 1
             set_surface()
             @parent.handle_request(:GET, :send_event, 'Hit')
-          else
-            #pass ## FIXME
           end
         end
         set_state('dodge') unless check_mikire().zero?
       elsif @settings['state'] == 'hit'
-        if @data.include?('hit.waittime')
-          wait_time = @data['hit.waittime']
-        else
-          wait_time = 0
-        end
+        wait_time = @data.include?('hit.waittime') ? @data['hit.waittime'] : 0
         if @hit_stop >= wait_time
           set_state('after')
           set_movement('after')
@@ -827,8 +734,6 @@ module Nekodorif
             @id = 2
             set_surface()
             @parent.handle_request(:GET, :send_event, 'Drop')
-          else
-            #pass ## FIXME
           end
         else
           @hit_stop += 1
@@ -841,21 +746,15 @@ module Nekodorif
       elsif @settings['state'] == 'end'
         if @parent.handle_request(:GET, :get_mode) == 1
           @parent.handle_request(:GET, :send_event, 'Vanish')
-        else
-          #pass ## FIXME
         end
         @parent.handle_request(:GET, :delete_katochan)
         return false
       elsif @settings['state'] == 'dodge'
         if @parent.handle_request(:GET, :get_mode) == 1
           @parent.handle_request(:GET, :send_event, 'Dodge')
-        else
-          #pass ## FIXME
         end
         @parent.handle_request(:GET, :delete_katochan)
         return false
-      else
-        ## check collision and mikire
       end
       @time += 1
       return true

--- a/lib/ninix/ngm.rb
+++ b/lib/ninix/ngm.rb
@@ -737,13 +737,16 @@ module NGM
       @url['Public'][0] = url
       label = @url['Public'][1]
       label.set_markup('<span foreground="blue">' + text.to_s + '</span>')
-      target_dir = File.join(
-                             @parent.handle_request(:GET, :get_home_dir),
-                             'ghost',
-                             @parent.handle_request(:GET, :get, 'InstallDir'))
-      @button['install'].set_sensitive(
-                                       (not File.directory?(target_dir) and
-                                       @parent.handle_request(:GET, :get, 'ArchiveUrl') != 'No data'))
+      home_dir = @parent.handle_request(:GET, :get_home_dir)
+install_dir = @parent.handle_request(:GET, :get, 'InstallDir')
+if home_dir && install_dir
+  target_dir = File.join(home_dir, 'ghost', install_dir)
+  @button['install'].set_sensitive(
+                                   (not File.directory?(target_dir) and
+                                   @parent.handle_request(:GET, :get, 'ArchiveUrl') != 'No data'))
+else
+  @button['install'].set_sensitive(false)
+end
       @button['update'].set_sensitive(
                                       (File.directory?(target_dir) and
                                        @parent.handle_request(:GET, :get, 'GhostType') == 'ゴースト' and

--- a/lib/ninix/pix.rb
+++ b/lib/ninix/pix.rb
@@ -93,9 +93,10 @@ module Pix
       super()
       set_decorated(false)
       provider = Gtk::CssProvider.new()
-      provider.load_from_data(TRANSPARENT_CSS)
-      sc = style_context
-      sc.add_provider(provider, Gtk::StyleProvider::PRIORITY_USER)
+      provider.load_from_string(TRANSPARENT_CSS)
+      # GTK4: style_context/add_provider gone; register at display level
+      Gtk::StyleContext.add_provider_for_display(
+        Gdk::Display.default, provider, Gtk::StyleProvider::PRIORITY_USER)
       #set_resizable(false)
       if monitor.nil? and not ENV.include?('NINIX_MONITOR_SIZE')
         id = signal_connect('notify') do |obj, spec|
@@ -223,9 +224,10 @@ module Pix
       super(application)
       set_decorated(false)
       provider = Gtk::CssProvider.new()
-      provider.load_from_data(TRANSPARENT_CSS)
-      sc = style_context
-      sc.add_provider(provider, Gtk::StyleProvider::PRIORITY_USER)
+      provider.load_from_string(TRANSPARENT_CSS)
+      # GTK4: style_context/add_provider gone; register at display level
+      Gtk::StyleContext.add_provider_for_display(
+        Gdk::Display.default, provider, Gtk::StyleProvider::PRIORITY_USER)
       show
       surface.set_input_region(Cairo::Region.new)
       hide

--- a/lib/ninix/pix.rb
+++ b/lib/ninix/pix.rb
@@ -18,9 +18,8 @@ require "gtk4"
 require_relative "logging"
 
 module Pix
-  TRANSPARENT_CSS = 'window { background-color: rgba(0, 0, 0, 0); }'
+  TRANSPARENT_CSS = '.ninix-transparent { background-color: rgba(0, 0, 0, 0); }'
   Rect = Struct.new(:x, :y, :width, :height)
-
   def self.surface_to_region(surface)
     region = Cairo::Region.new()
     width = surface.width
@@ -91,6 +90,7 @@ module Pix
     def initialize(monitor = nil)
       @width, @height = 1, 1
       super()
+      add_css_class('ninix-transparent')
       set_decorated(false)
       provider = Gtk::CssProvider.new()
       provider.load_from_string(TRANSPARENT_CSS)
@@ -222,6 +222,7 @@ module Pix
 
     def initialize(application)
       super(application)
+      add_css_class('ninix-transparent')
       set_decorated(false)
       provider = Gtk::CssProvider.new()
       provider.load_from_string(TRANSPARENT_CSS)

--- a/lib/ninix/sakura.rb
+++ b/lib/ninix/sakura.rb
@@ -3739,12 +3739,11 @@ module Sakura
       @surface.get_info(key)
     end
 
-    def select_shell_from_ao(key)
-      @parent.handle_request(:GET, :select_shell, key)
-    end
-
-    def select_balloon_from_ao(key)
-      @parent.handle_request(:GET, :select_balloon, key)
+    [:select_sakura, :start_sakura_cb, :select_shell, :close_sakura].each do |x|
+      define_method(x) do |*args|
+        @parent.handle_request(:NOTIFY, :change_owner, self)
+        @parent.handle_request(:NOTIFY, x, *args)
+      end
     end
   end
 

--- a/lib/ninix/sakura.rb
+++ b/lib/ninix/sakura.rb
@@ -85,7 +85,7 @@ module Sakura
     BROWSE_MODE        = 1
     SELECT_MODE        = 2
     PAUSE_MODE         = 3
-    WAIT_MODE          = 4 
+    WAIT_MODE          = 4
     PAUSE_NOCLEAR_MODE = 5
     # script origins
     FROM_SSTP_CLIENT = 1
@@ -105,7 +105,7 @@ module Sakura
       '\+',
       '\_+',
     ]
- 
+
     def initialize
       super("") # FIXME
       @handlers = {
@@ -351,7 +351,7 @@ module Sakura
         @vanished_count = ghost_vanished_count
       end
     end
- 
+
     def load_settings()
       path = File.join(get_prefix(), 'SETTINGS')
       if File.exist?(path)
@@ -1502,6 +1502,14 @@ module Sakura
 
     def toggle_bind(side, bind_id, from)
       @surface.toggle_bind(side, bind_id, from)
+    end
+
+    def get_popup_parent_window(side)
+        surface_window = @surface.window[side]
+        return nil if surface_window.nil?
+        surface_window.windows&.first&.darea
+    rescue
+        nil
     end
 
     def get_menu_pixmap()
@@ -3441,7 +3449,7 @@ module Sakura
       '\_V' => "__yen__V",
       '\!' => "__yen_exclamation",
       '\__c' => "__yen___c",
-      '\__t' => "__yen___t", 
+      '\__t' => "__yen___t",
       '\v' => "__yen_v",
       '\f' => "__yen_f",
       '\C' => nil, # dummy
@@ -3745,7 +3753,7 @@ module Sakura
     include GetText
 
     bindtextdomain("ninix-kagari")
-    
+
     def initialize
       @parent = nil # dummy
       @dialog = Gtk::Dialog.new

--- a/lib/ninix/surface.rb
+++ b/lib/ninix/surface.rb
@@ -908,17 +908,6 @@ module Surface
         default_id, @maxsize)
       surface_window.set_responsible(self)
       @window[side] = surface_window
-      if @window[side].loading?
-        GLib::Idle.add do
-          next false if @window[side].nil?
-          next true if @window[side].loading?
-          @window_queue[side].each do |f|
-            f.call
-          end
-          @window_queue.delete(side)
-          next false
-        end
-      end
     end
 
     def get_mayuna_menu

--- a/lib/ninix/surface.rb
+++ b/lib/ninix/surface.rb
@@ -456,7 +456,7 @@ module Surface
         gtk_window.set_keep_above(flag)
       end
     end
-         
+
     def window_iconify(flag)
       gtk_window = @window[0].window
       iconified = (gtk_window.window.state & \
@@ -1361,7 +1361,7 @@ module Surface
   end
 
   class SurfaceWindow < MetaMagic::Holon
-    attr_reader :bind
+    attr_reader :bind, :windows
 
     OPERATOR = {
       'base' =>            Cairo::OPERATOR_SOURCE, # XXX
@@ -1736,7 +1736,7 @@ module Surface
       end
       return mayuna_list
     end
-    
+
     def create_surface_from_file(surface_id, is_asis: false, check_only: false)
       fail "assert" unless @surfaces.include?(surface_id)
       overlay = @surfaces[surface_id][1, @surfaces[surface_id].length - 1]

--- a/lib/ninix/surface.rb
+++ b/lib/ninix/surface.rb
@@ -910,6 +910,7 @@ module Surface
       @window[side] = surface_window
       if @window[side].loading?
         GLib::Idle.add do
+          next false if @window[side].nil?
           next true if @window[side].loading?
           @window_queue[side].each do |f|
             f.call

--- a/lib/ninix_main.rb
+++ b/lib/ninix_main.rb
@@ -116,7 +116,7 @@ module Ninix_Main
   end
 
   class Ghost < MetaMagic::Holon
-
+    attr_accessor :menuitem
     def create_menuitem(data)
       @parent.handle_request(:GET, :create_menuitem, @key, data)
     end
@@ -243,6 +243,7 @@ module Ninix_Main
         holon.set_responsible(self)
         @ghosts[key] = holon
         holon.baseinfo = value
+        holon.create_menuitem(value)
       end
       @balloons = {} # Ordered Hash
       odict_baseinfo = Home.search_balloons()
@@ -542,6 +543,8 @@ module Ninix_Main
     end
 
     def select_sakura(key)
+      Logging::Logging.info("select_sakura called with key=#{key}")
+      @__menu.reset_popup_window
       if @__menu_owner.busy()
         Gdk.beep()
         return
@@ -1012,11 +1015,15 @@ module Ninix_Main
       elsif event.zero?
         proc_obj.call()
       else
-        sakura_name = @ghosts[key].instance.get_selfname(:default => '')
-        name = @ghosts[key].instance.get_name(:default => '')
-        sakura.enqueue_event(
-          'OnGhostChanging', sakura_name, method, name, key,
-          :proc_obj => proc_obj)
+        if @ghosts[key].instance
+          sakura_name = @ghosts[key].instance.get_selfname(:default => '')
+          name = @ghosts[key].instance.get_name(:default => '')
+          sakura.enqueue_event(
+           'OnGhostChanging', sakura_name, method, name, key,
+           :proc_obj => proc_obj)
+        else
+          proc_obj.call()
+        end
       end
     end
 

--- a/lib/ninix_main.rb
+++ b/lib/ninix_main.rb
@@ -241,7 +241,7 @@ module Ninix_Main
       for key, value in odict_baseinfo
         holon = Ghost.new(key)
         holon.set_responsible(self)
-        @ghosts[key] = holon 
+        @ghosts[key] = holon
         holon.baseinfo = value
       end
       @balloons = {} # Ordered Hash
@@ -624,7 +624,8 @@ module Ninix_Main
         end
       end
       r = monitor.geometry
-      @__menu.popup(side, x - r.x, y - r.y, upper)
+      parent_window = @__menu_owner.get_popup_parent_window(side)
+      @__menu.popup(side, x - r.x, y - r.y, upper, parent_window)
     end
 
     def get_ghost_menus
@@ -1103,7 +1104,7 @@ module Ninix_Main
         @ghosts.delete(key)
         return ## FIXME
       end
-      start_sakura(key, :prev => key, :init => true) 
+      start_sakura(key, :prev => key, :init => true)
     end
 
     def add_sakura(ghost_dir)

--- a/lib/ninix_main.rb
+++ b/lib/ninix_main.rb
@@ -522,7 +522,7 @@ module Ninix_Main
       @__menu_owner.select_shell(key)
     end
 
-    def select_balloon(key)
+    def select_balloon(key, *args)
       desc, balloon = get_balloon_description(key)
       @__menu_owner.select_balloon(key, desc, balloon)
     end


### PR DESCRIPTION
masterブランチにGTK4対応のパッチをリベースし、kinoko.rbとnekodorif.rbのGTK4移植を追加しました。

変更内容:
- pix.rb: load_from_data/style_contextをload_from_string/add_provider_for_displayに置き換え（ウィンドウ透過修正）
- menu.rb: Gio::MenuItem.newの呼び出し修正、popup()をゴーストのDrawingAreaを親とするPopoverMenuに書き直し
- sakura.rb: get_popup_parent_windowを追加、select_shell_from_ao/select_balloon_from_aoをdefine_methodループに置き換え
- surface.rb: ウィンドウ読み込みのIdleコールバックにnilガードを追加
- ninix_main.rb: parent_windowをopen_popup_menuを通じてmenu.popup()に渡すよう変更
- kinoko.rb: Gio::Menu/PopoverMenu、GestureClick、EventControllerMotion、set_draw_funcによるGTK4への完全書き直し
- nekodorif.rb: kinoko同様の変更に加え、EventControllerKeyとウィジェット相対座標によるドラッグ処理を実装

Fedora + GNOME/Wayland環境でテスト済み。